### PR TITLE
Set theme value

### DIFF
--- a/src/Core/BreadProvider.js
+++ b/src/Core/BreadProvider.js
@@ -4,10 +4,18 @@ import ThemeContext from '../Theme/ThemeContext';
 
 export default class BreadProvider extends Component {
   static propTypes = {
-    children: PropTypes.node,
+    children: PropTypes.node.isRequired,
+    value: PropTypes.object,
   };
+
+  static defaultProps = {
+    value: {},
+  };
+
   render() {
-    const { children } = this.props;
-    return <ThemeContext.Provider value={{}}>{children}</ThemeContext.Provider>;
+    const { children, value } = this.props;
+    return (
+      <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+    );
   }
 }


### PR DESCRIPTION
The value prop for the ThemeContext Provider in BreadProvider was not being set.  This meant that the theme set by the user was never used or merged with default.