### PR TITLE
Fixed Require Cycling

### DIFF
--- a/src/Components/Appbar/Searchbar/Searchbar.styles.js
+++ b/src/Components/Appbar/Searchbar/Searchbar.styles.js
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import shadow from '../../../Utils/Shadow/shadow';
+import shadow from '../../../Utils/Shadow/shadow.js';
 
 const styles = StyleSheet.create({
   container: {

--- a/src/Components/Appbar/Searchbar/Searchbar.styles.js
+++ b/src/Components/Appbar/Searchbar/Searchbar.styles.js
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { shadow } from '../../..';
+import shadow from '../../../Utils/Shadow/shadow';
 
 const styles = StyleSheet.create({
   container: {

--- a/src/Components/Dialog/Dialog.js
+++ b/src/Components/Dialog/Dialog.js
@@ -5,8 +5,8 @@ import PropTypes from 'prop-types';
 import Modal from '../Modal/Modal.js';
 import withTheme from '../../Theme/withTheme';
 import styles from './Dialog.styles';
-import Button from '../Button/Button';
-import BodyText from '../Typography/BodyText/BodyText';
+import Button from '../Button/Button.js';
+import BodyText from '../Typography/BodyText/BodyText.js';
 class Dialog extends Component {
   static propTypes = {
     style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),

--- a/src/Components/Dialog/Dialog.js
+++ b/src/Components/Dialog/Dialog.js
@@ -5,7 +5,8 @@ import PropTypes from 'prop-types';
 import Modal from '../Modal/Modal.js';
 import withTheme from '../../Theme/withTheme';
 import styles from './Dialog.styles';
-import { Button, BodyText } from '../..';
+import Button from '../Button/Button';
+import BodyText from '../Typography/BodyText/BodyText';
 class Dialog extends Component {
   static propTypes = {
     style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),

--- a/src/Components/Divider/Divider.js
+++ b/src/Components/Divider/Divider.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { View, Platform, StyleSheet } from 'react-native';
 import withTheme from '../../Theme/withTheme';
-import BodyText from '../Typography/BodyText/BodyText';
+import BodyText from '../Typography/BodyText/BodyText.js';
 import styles from './Divider.styles';
 
 class Divider extends Component {

--- a/src/Components/Divider/Divider.js
+++ b/src/Components/Divider/Divider.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { View, Platform, StyleSheet } from 'react-native';
 import withTheme from '../../Theme/withTheme';
-import { BodyText } from '../..';
+import BodyText from '../Typography/BodyText/BodyText';
 import styles from './Divider.styles';
 
 class Divider extends Component {

--- a/src/Components/DrawerBottom/DrawerBottom.js
+++ b/src/Components/DrawerBottom/DrawerBottom.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import withTheme from '../../Theme/withTheme';
-import { SheetBottom } from '../../';
+import SheetBottom from '../SheetBottom/SheetBottom';
 
 class DrawerBottom extends Component {
   static propTypes = {

--- a/src/Components/DrawerBottom/DrawerBottom.js
+++ b/src/Components/DrawerBottom/DrawerBottom.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import withTheme from '../../Theme/withTheme';
-import SheetBottom from '../SheetBottom/SheetBottom';
+import SheetBottom from '../SheetBottom/SheetBottom.js';
 
 class DrawerBottom extends Component {
   static propTypes = {

--- a/src/Components/Fab/Fab.js
+++ b/src/Components/Fab/Fab.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import { Animated } from 'react-native';
 
 import withTheme from '../../Theme/withTheme';
-import Icon from '../Icon/Icon';
-import Ripple from '../Ripple/Ripple';
-import BodyText from '../Typography/BodyText/BodyText';
+import Icon from '../Icon/Icon.js';
+import Ripple from '../Ripple/Ripple.js';
+import BodyText from '../Typography/BodyText/BodyText.js';
 import shadowTool from '../../Utils/Shadow/shadow';
 import styles from './Fab.styles';
 

--- a/src/Components/Fab/Fab.js
+++ b/src/Components/Fab/Fab.js
@@ -6,7 +6,7 @@ import withTheme from '../../Theme/withTheme';
 import Icon from '../Icon/Icon.js';
 import Ripple from '../Ripple/Ripple.js';
 import BodyText from '../Typography/BodyText/BodyText.js';
-import shadowTool from '../../Utils/Shadow/shadow';
+import shadowTool from '../../Utils/Shadow/shadow.js';
 import styles from './Fab.styles';
 
 export class Fab extends Component {

--- a/src/Components/Fab/Fab.js
+++ b/src/Components/Fab/Fab.js
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import { Animated } from 'react-native';
 
 import withTheme from '../../Theme/withTheme';
-import { Icon, Ripple, BodyText } from '../../';
+import Icon from '../Icon/Icon';
+import Ripple from '../Ripple/Ripple';
+import BodyText from '../Typography/BodyText/BodyText';
 import shadowTool from '../../Utils/Shadow/shadow';
 import styles from './Fab.styles';
 

--- a/src/Components/Fab/FabSpeedDial/FabSpeedDial.js
+++ b/src/Components/Fab/FabSpeedDial/FabSpeedDial.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { View, Animated } from 'react-native';
 import withTheme from '../../../Theme/withTheme';
-import { Fab } from '../../..';
+import Fab from '../Fab';
 import styles from './FabSpeedDial.styles';
 
 class FabSpeedDial extends Component {

--- a/src/Components/Fab/FabSpeedDial/FabSpeedDial.js
+++ b/src/Components/Fab/FabSpeedDial/FabSpeedDial.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { View, Animated } from 'react-native';
 import withTheme from '../../../Theme/withTheme';
-import Fab from '../Fab';
+import Fab from '../Fab.js';
 import styles from './FabSpeedDial.styles';
 
 class FabSpeedDial extends Component {

--- a/src/Components/List/List.js
+++ b/src/Components/List/List.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import withTheme from '../../Theme/withTheme';
-import BodyText from '../Typography/BodyText/BodyText';
-import Paper from '../Paper/Paper';
+import BodyText from '../Typography/BodyText/BodyText.js';
+import Paper from '../Paper/Paper.js';
 import styles from './List.styles';
 
 class List extends Component {

--- a/src/Components/List/List.js
+++ b/src/Components/List/List.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import withTheme from '../../Theme/withTheme';
-import { BodyText, Paper } from '../../';
+import BodyText from '../Typography/BodyText/BodyText';
+import Paper from '../Paper/Paper';
 import styles from './List.styles';
 
 class List extends Component {

--- a/src/Components/List/ListItem/ListItem.js
+++ b/src/Components/List/ListItem/ListItem.js
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
 import withTheme from '../../../Theme/withTheme';
-import { BodyText, Caption, Ripple } from '../../..';
+import BodyText from '../../Typography/BodyText/BodyText';
+import Caption from '../../Typography/Caption/Caption';
+import Ripple from '../../Ripple/Ripple';
 import styles from './ListItem.styles';
 
 class ListItem extends Component {

--- a/src/Components/List/ListItem/ListItem.js
+++ b/src/Components/List/ListItem/ListItem.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
 import withTheme from '../../../Theme/withTheme';
-import BodyText from '../../Typography/BodyText/BodyText';
-import Caption from '../../Typography/Caption/Caption';
-import Ripple from '../../Ripple/Ripple';
+import BodyText from '../../Typography/BodyText/BodyText.js';
+import Caption from '../../Typography/Caption/Caption.js';
+import Ripple from '../../Ripple/Ripple.js';
 import styles from './ListItem.styles';
 
 class ListItem extends Component {

--- a/src/Components/List/ListSection/ListSection.js
+++ b/src/Components/List/ListSection/ListSection.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { View, Text, Platform } from 'react-native';
 import withTheme from '../../../Theme/withTheme';
 
-import { Divider } from '../../..';
+import Divider from '../../Divider/Divider';
 import styles from './ListSection.styles';
 
 class ListSection extends Component {

--- a/src/Components/List/ListSection/ListSection.js
+++ b/src/Components/List/ListSection/ListSection.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { View, Text, Platform } from 'react-native';
 import withTheme from '../../../Theme/withTheme';
 
-import Divider from '../../Divider/Divider';
+import Divider from '../../Divider/Divider.js';
 import styles from './ListSection.styles';
 
 class ListSection extends Component {

--- a/src/Components/Menu/MenuItem/MenuItem.js
+++ b/src/Components/Menu/MenuItem/MenuItem.js
@@ -4,7 +4,8 @@ import PropTypes from 'prop-types';
 import { Text, Platform, View } from 'react-native';
 import withTheme from '../../../Theme/withTheme';
 import styles from './MenuItem.styles';
-import { Ripple, Hoverable } from '../../../';
+import Ripple from '../../Ripple/Ripple';
+import Hoverable from '../../../Utils/Hoverable/Hoverable';
 
 class MenuItem extends Component {
   constructor(props) {

--- a/src/Components/Menu/MenuItem/MenuItem.js
+++ b/src/Components/Menu/MenuItem/MenuItem.js
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 import { Text, Platform, View } from 'react-native';
 import withTheme from '../../../Theme/withTheme';
 import styles from './MenuItem.styles';
-import Ripple from '../../Ripple/Ripple';
-import Hoverable from '../../../Utils/Hoverable/Hoverable';
+import Ripple from '../../Ripple/Ripple.js';
+import Hoverable from '../../../Utils/Hoverable/Hoverable.js';
 
 class MenuItem extends Component {
   constructor(props) {

--- a/src/Components/Select/Select.js
+++ b/src/Components/Select/Select.js
@@ -2,7 +2,10 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { TouchableHighlight, View, FlatList, Platform } from 'react-native';
 
-import { Menu, MenuItem, Icon, TextField } from '../../..';
+import Menu from '../Menu/Menu';
+import MenuItem from '../Menu/MenuItem/MenuItem';
+import Icon from '../Icon/Icon';
+import TextField from '../TextField/TextField';
 
 import withTheme from '../../Theme/withTheme';
 import styles from './Select.styles';

--- a/src/Components/Select/Select.js
+++ b/src/Components/Select/Select.js
@@ -2,10 +2,10 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { TouchableHighlight, View, FlatList, Platform } from 'react-native';
 
-import Menu from '../Menu/Menu';
-import MenuItem from '../Menu/MenuItem/MenuItem';
-import Icon from '../Icon/Icon';
-import TextField from '../TextField/TextField';
+import Menu from '../Menu/Menu.js';
+import MenuItem from '../Menu/MenuItem/MenuItem.js';
+import Icon from '../Icon/Icon.js';
+import TextField from '../TextField/TextField.js';
 
 import withTheme from '../../Theme/withTheme';
 import styles from './Select.styles';

--- a/src/Components/Slider/Marker/Marker.js
+++ b/src/Components/Slider/Marker/Marker.js
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import styles from './Marker.styles';
 import withTheme from '../../../Theme/withTheme';
-import Ripple from '../../Ripple/Ripple';
-import Hoverable from '../../../Utils/Hoverable/Hoverable';
+import Ripple from '../../Ripple/Ripple.js';
+import Hoverable from '../../../Utils/Hoverable/Hoverable.js';
 import colorTool from 'color';
 
 class Marker extends Component {

--- a/src/Components/Slider/Marker/Marker.js
+++ b/src/Components/Slider/Marker/Marker.js
@@ -4,7 +4,8 @@ import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import styles from './Marker.styles';
 import withTheme from '../../../Theme/withTheme';
-import { Ripple, Hoverable } from '../../..';
+import Ripple from '../../Ripple/Ripple';
+import Hoverable from '../../../Utils/Hoverable/Hoverable';
 import colorTool from 'color';
 
 class Marker extends Component {

--- a/src/Components/Snackbar/Snackbar.styles.js
+++ b/src/Components/Snackbar/Snackbar.styles.js
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { shadow } from '../..';
+import shadow from '../../Utils/Shadow/shadow';
 
 const styles = StyleSheet.create({
   container: {

--- a/src/Components/Snackbar/Snackbar.styles.js
+++ b/src/Components/Snackbar/Snackbar.styles.js
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import shadow from '../../Utils/Shadow/shadow';
+import shadow from '../../Utils/Shadow/shadow.js';
 
 const styles = StyleSheet.create({
   container: {

--- a/src/Components/Switch/Switch.js
+++ b/src/Components/Switch/Switch.js
@@ -3,7 +3,8 @@ import { Animated, View, TouchableWithoutFeedback } from 'react-native';
 import PropTypes from 'prop-types';
 import withTheme from '../../Theme/withTheme';
 
-import { Ripple, ProgressCircle } from '../../';
+import Ripple from '../Ripple/Ripple';
+import ProgressCircle from '../Progress/ProgressCircle/ProgressCircle';
 import styles from './Switch.styles';
 import colorTool from 'color';
 

--- a/src/Components/Switch/Switch.js
+++ b/src/Components/Switch/Switch.js
@@ -3,8 +3,8 @@ import { Animated, View, TouchableWithoutFeedback } from 'react-native';
 import PropTypes from 'prop-types';
 import withTheme from '../../Theme/withTheme';
 
-import Ripple from '../Ripple/Ripple';
-import ProgressCircle from '../Progress/ProgressCircle/ProgressCircle';
+import Ripple from '../Ripple/Ripple.js';
+import ProgressCircle from '../Progress/ProgressCircle/ProgressCircle.js';
 import styles from './Switch.styles';
 import colorTool from 'color';
 

--- a/src/Components/Switch/Switch.styles.js
+++ b/src/Components/Switch/Switch.styles.js
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { shadow } from '../..';
+import shadow from '../../Utils/Shadow/shadow';
 
 const styles = StyleSheet.create({
   container: {

--- a/src/Components/Switch/Switch.styles.js
+++ b/src/Components/Switch/Switch.styles.js
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import shadow from '../../Utils/Shadow/shadow';
+import shadow from '../../Utils/Shadow/shadow.js';
 
 const styles = StyleSheet.create({
   container: {

--- a/src/Components/Tabs/Tab/Tab.js
+++ b/src/Components/Tabs/Tab/Tab.js
@@ -2,7 +2,8 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import { View, Text } from 'react-native';
-import { Ripple, Icon } from '../../../';
+import Ripple from '../../Ripple/Ripple';
+import Icon from '../../Icon/Icon';
 import withTheme from '../../../Theme/withTheme';
 import styles from './Tab.styles';
 

--- a/src/Components/Tabs/Tab/Tab.js
+++ b/src/Components/Tabs/Tab/Tab.js
@@ -2,8 +2,8 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import { View, Text } from 'react-native';
-import Ripple from '../../Ripple/Ripple';
-import Icon from '../../Icon/Icon';
+import Ripple from '../../Ripple/Ripple.js';
+import Icon from '../../Icon/Icon.js';
 import withTheme from '../../../Theme/withTheme';
 import styles from './Tab.styles';
 

--- a/src/Components/TextField/Searchfield/Searchfield.styles.js
+++ b/src/Components/TextField/Searchfield/Searchfield.styles.js
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import shadow from '../../../Utils/Shadow/shadow';
+import shadow from '../../../Utils/Shadow/shadow.js';
 
 const styles = StyleSheet.create({
   container: {

--- a/src/Components/TextField/Searchfield/Searchfield.styles.js
+++ b/src/Components/TextField/Searchfield/Searchfield.styles.js
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { shadow } from '../../..';
+import shadow from '../../../Utils/Shadow/shadow';
 
 const styles = StyleSheet.create({
   container: {

--- a/src/Components/Tooltip/Tooltip.js
+++ b/src/Components/Tooltip/Tooltip.js
@@ -2,7 +2,10 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Platform, Text, View, TouchableWithoutFeedback } from 'react-native';
 
-import { Paper, Menu, shadow, Hoverable } from '../..';
+import Paper from '../Paper/Paper';
+import Menu from '../Menu/Menu';
+import shadow from '../../Utils/Shadow/shadow';
+import Hoverable from '../../Utils/Hoverable/Hoverable';
 
 import withTheme from '../../Theme/withTheme';
 import styles from './Tooltip.styles';

--- a/src/Components/Tooltip/Tooltip.js
+++ b/src/Components/Tooltip/Tooltip.js
@@ -4,7 +4,7 @@ import { Platform, Text, View, TouchableWithoutFeedback } from 'react-native';
 
 import Paper from '../Paper/Paper.js';
 import Menu from '../Menu/Menu.js';
-import shadow from '../../Utils/Shadow/shadow';
+import shadow from '../../Utils/Shadow/shadow.js';
 import Hoverable from '../../Utils/Hoverable/Hoverable.js';
 
 import withTheme from '../../Theme/withTheme';

--- a/src/Components/Tooltip/Tooltip.js
+++ b/src/Components/Tooltip/Tooltip.js
@@ -2,10 +2,10 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Platform, Text, View, TouchableWithoutFeedback } from 'react-native';
 
-import Paper from '../Paper/Paper';
-import Menu from '../Menu/Menu';
+import Paper from '../Paper/Paper.js';
+import Menu from '../Menu/Menu.js';
 import shadow from '../../Utils/Shadow/shadow';
-import Hoverable from '../../Utils/Hoverable/Hoverable';
+import Hoverable from '../../Utils/Hoverable/Hoverable.js';
 
 import withTheme from '../../Theme/withTheme';
 import styles from './Tooltip.styles';


### PR DESCRIPTION
Fix for #195 

Fixed all Require Cycling warnings being thrown by importing components from their modules instead of from src/index.js.  I'm not sure this is how this should be handled architecturally.  I understand the want to import from a common source, but a user shouldn't have to close 15 warnings to use the library.

@codypearce if you'd like me to address this in a different way let me know.