### PR TITLE
Fixed overflow & docs issue

### DIFF
--- a/docs/src/content/components/progress-circle/index.js
+++ b/docs/src/content/components/progress-circle/index.js
@@ -21,7 +21,7 @@ export default class DataTableHeaderPage extends Component {
           componentName={'progress-circle'}
           title={'Progress Circle'}
           description={`Progress indicators express an unspecified wait time or display the length of a process.`}
-          importCode={`import { ProgressBar } from 'material-bread';`}
+          importCode={`import { ProgressCircle } from 'material-bread';`}
           docsLink={
             'https://material.io/design/components/progress-indicators.html#circular-progress-indicators'
           }

--- a/src/Components/Checkbox/Checkbox.js
+++ b/src/Components/Checkbox/Checkbox.js
@@ -74,7 +74,7 @@ class Checkbox extends Component {
 
     return (
       <TouchableWithoutFeedback onPress={onPress}>
-        <View>
+        <View style={styles.labelContainer}>
           <Text style={[styles.label, labelStyle]}>{label}</Text>
         </View>
       </TouchableWithoutFeedback>

--- a/src/Components/Checkbox/Checkbox.styles.js
+++ b/src/Components/Checkbox/Checkbox.styles.js
@@ -13,6 +13,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  labelContainer: { flexShrink: 1 },
   label: {},
 });
 


### PR DESCRIPTION
Fixed the checkbox overflow by adding a flex shrink to the container.  Also fixed an issue in the docs in ProgressCircle.

This fixes #203 and #204 

<img width="391" alt="Screen Shot 2019-06-20 at 12 33 27 PM" src="https://user-images.githubusercontent.com/22638838/59865674-a1f2ea00-9357-11e9-91bb-446804576b7d.png">
