### PR TITLE
Set Default for Ripple testID

### DIFF
--- a/src/Components/Chip/__snapshots__/Chip.test.js.snap
+++ b/src/Components/Chip/__snapshots__/Chip.test.js.snap
@@ -48,7 +48,7 @@ exports[`Chip Renders 1`] = `
         "height": "100%",
       }
     }
-    testID={[Function]}
+    testID="mb-ripple"
   >
     <View
       style={

--- a/src/Components/Drawer/DrawerItem/__snapshots__/DrawerItem.test.js.snap
+++ b/src/Components/Drawer/DrawerItem/__snapshots__/DrawerItem.test.js.snap
@@ -31,7 +31,7 @@ exports[`DrawerItem Renders 1`] = `
       "zIndex": 10,
     }
   }
-  testID={[Function]}
+  testID="mb-ripple"
 >
   <Text
     style={

--- a/src/Components/Menu/MenuItem/__snapshots__/MenuItem.test.js.snap
+++ b/src/Components/Menu/MenuItem/__snapshots__/MenuItem.test.js.snap
@@ -44,7 +44,7 @@ exports[`MenuItem Renders 1`] = `
         "width": "100%",
       }
     }
-    testID={[Function]}
+    testID="mb-ripple"
   >
     <Text
       ellipsizeMode="clip"

--- a/src/Components/RadioButton/__snapshots__/RadioButton.test.js.snap
+++ b/src/Components/RadioButton/__snapshots__/RadioButton.test.js.snap
@@ -40,7 +40,7 @@ exports[`RadioButton Renders 1`] = `
         "width": 40,
       }
     }
-    testID={[Function]}
+    testID="mb-ripple"
   >
     <View
       style={

--- a/src/Components/Ripple/Ripple.js
+++ b/src/Components/Ripple/Ripple.js
@@ -25,7 +25,7 @@ export default class Ripple extends PureComponent {
     displayUntilPressOut: true,
 
     onRippleAnimation: (animation, callback) => animation.start(callback),
-    testID: PropTypes.string,
+    testID: 'mb-ripple',
   };
 
   static propTypes = {
@@ -44,6 +44,7 @@ export default class Ripple extends PureComponent {
     displayUntilPressOut: PropTypes.bool,
 
     onRippleAnimation: PropTypes.func,
+    testID: PropTypes.string,
   };
 
   constructor(props) {

--- a/src/Components/Ripple/__snapshots__/Ripple.test.js.snap
+++ b/src/Components/Ripple/__snapshots__/Ripple.test.js.snap
@@ -20,7 +20,7 @@ exports[`Ripple Renders 1`] = `
   rippleOpacity={0.3}
   rippleSequential={false}
   rippleSize={0}
-  testID={[Function]}
+  testID="mb-ripple"
 >
   <View
     style={


### PR DESCRIPTION
The issue here was that without the default prop, not sending in a testID to Ripple would cause Android's JSC to coercing the null into a boolean and then attempt to apply it to a string prop.  This caused Android to red screen error.

Fixes #208 