### PR TITLE
Android - Typed text is a little low

### DIFF
--- a/src/Components/TextField/TextFieldFilled/TextFieldFilled.styles.js
+++ b/src/Components/TextField/TextFieldFilled/TextFieldFilled.styles.js
@@ -4,7 +4,6 @@ const styles = StyleSheet.create({
     position: 'relative',
   },
   textField: {
-    textAlignVertical: 'bottom',
     paddingHorizontal: 12,
   },
 

--- a/src/Components/TextField/TextFieldFilled/__snapshots__/TextFieldFilled.test.js.snap
+++ b/src/Components/TextField/TextFieldFilled/__snapshots__/TextFieldFilled.test.js.snap
@@ -45,7 +45,6 @@ exports[`TextFieldFilled Renders 1`] = `
       Array [
         Object {
           "paddingHorizontal": 12,
-          "textAlignVertical": "bottom",
         },
         Object {
           "backgroundColor": "#d9d9d9",


### PR DESCRIPTION
Fix for https://github.com/codypearce/material-bread/issues/216
- textAlignVertical only works on Android so is generating a misalignment between iOS and Android


Before: 

![image](https://user-images.githubusercontent.com/41348080/61249038-53e8c080-a722-11e9-906c-bc96e1bab0eb.png)
After: 

![image](https://user-images.githubusercontent.com/41348080/61249073-67942700-a722-11e9-8db9-0dd4ccdfdefc.png)
