### PR TITLE
Button components use containerStyle

### DIFF
--- a/src/Components/Button/ContainedButton/ContainedButton.js
+++ b/src/Components/Button/ContainedButton/ContainedButton.js
@@ -185,7 +185,8 @@ class ContainedButton extends Component {
     return (
       <Hoverable
         onHoverIn={() => this.handleHover(true)}
-        onHoverOut={() => this.handleHover(false)}>
+        onHoverOut={() => this.handleHover(false)}
+        style={containerStyle}>
         {() => (
           <Animated.View
             style={[
@@ -194,7 +195,6 @@ class ContainedButton extends Component {
                 alignSelf: fullWidth ? 'auto' : 'flex-start',
                 borderRadius: radius ? radius : theme.button.borderRadius,
               },
-              containerStyle,
             ]}>
             <ButtonBase
               typeRippleColor={this.getRippleColor()}

--- a/src/Components/Button/FlatButton/FlatButton.js
+++ b/src/Components/Button/FlatButton/FlatButton.js
@@ -76,7 +76,8 @@ class FlatButton extends Component {
     return (
       <Hoverable
         onHoverIn={() => this.handleHover(true)}
-        onHoverOut={() => this.handleHover(false)}>
+        onHoverOut={() => this.handleHover(false)}
+        style={props.containerStyle}>
         {() => (
           <ButtonBase
             typeRippleColor={this.getRippleColor()}

--- a/src/Components/Button/OutlinedButton/OutlinedButton.js
+++ b/src/Components/Button/OutlinedButton/OutlinedButton.js
@@ -14,6 +14,7 @@ class OutlinedButton extends Component {
     rippleColor: PropTypes.string,
     theme: PropTypes.object,
     borderSize: PropTypes.number,
+    containerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   };
 
   state = {
@@ -82,7 +83,8 @@ class OutlinedButton extends Component {
     return (
       <Hoverable
         onHoverIn={() => this.handleHover(true)}
-        onHoverOut={() => this.handleHover(false)}>
+        onHoverOut={() => this.handleHover(false)}
+        style={props.containerStyle}>
         {() => (
           <ButtonBase
             typeRippleColor={this.getRippleColor()}

--- a/src/Components/Button/TextButton/TextButton.js
+++ b/src/Components/Button/TextButton/TextButton.js
@@ -13,6 +13,7 @@ class TextButton extends Component {
     textColor: PropTypes.string,
     rippleColor: PropTypes.string,
     theme: PropTypes.object,
+    containerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   };
 
   state = {
@@ -76,7 +77,8 @@ class TextButton extends Component {
     return (
       <Hoverable
         onHoverIn={() => this.handleHover(true)}
-        onHoverOut={() => this.handleHover(false)}>
+        onHoverOut={() => this.handleHover(false)}
+        style={props.containerStyle}>
         {() => (
           <ButtonBase
             typeRippleColor={this.getRippleColor()}

--- a/src/Utils/Hoverable/Hoverable.js
+++ b/src/Utils/Hoverable/Hoverable.js
@@ -17,6 +17,7 @@ class Hoverable extends Component {
     children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
     onHoverIn: PropTypes.func,
     onHoverOut: PropTypes.func,
+    style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     testID: PropTypes.string,
   };
 
@@ -65,7 +66,7 @@ class Hoverable extends Component {
   };
 
   render() {
-    const { children, testID } = this.props;
+    const { children, style, testID } = this.props;
     const { width } = this.state;
 
     const child =
@@ -81,7 +82,7 @@ class Hoverable extends Component {
     } else {
       return (
         <TouchableWithoutFeedback onPress={this._toggle} testID={testID}>
-          <View>
+          <View style={style}>
             {React.cloneElement(React.Children.only(child), {
               onMouseEnter: this._handleMouseEnter,
               onMouseLeave: this._handleMouseLeave,


### PR DESCRIPTION
The containerStyle prop is listed in the docs, but wasn't actually being used anywhere in most cases.

I was trying to use `width: '100%'` for the buttons inside a flex container with `alignItems: 'center'`, but it wasn't working because the style wasn't being applied to the button containers.