### PR TITLE
TextFields only render label if it exists

### DIFF
--- a/src/Components/TextField/TextFieldFilled/TextFieldFilled.js
+++ b/src/Components/TextField/TextFieldFilled/TextFieldFilled.js
@@ -153,18 +153,20 @@ class TextFieldFilled extends Component {
           { marginBottom: helperText && helperVisible ? 20 : 0 },
           containerStyle,
         ]}>
-        <TextFieldLabel
-          label={label}
-          focused={focused}
-          error={error}
-          value={rest.value && rest.value.length > 0}
-          labelColor={labelColor}
-          style={labelStyle}
-          leadingIcon={leadingIcon}
-          dense={dense}
-          prefix={prefix}
-          type={'filled'}
-        />
+        {label ? (
+          <TextFieldLabel
+            label={label}
+            focused={focused}
+            error={error}
+            value={rest.value && rest.value.length > 0}
+            labelColor={labelColor}
+            style={labelStyle}
+            leadingIcon={leadingIcon}
+            dense={dense}
+            prefix={prefix}
+            type={'filled'}
+          />
+        ) : null}
         {leadingIcon ? this._renderLeadingIcon() : null}
         {prefix ? this._renderPrefix() : null}
         <TextInput

--- a/src/Components/TextField/TextFieldFlat/TextFieldFlat.js
+++ b/src/Components/TextField/TextFieldFlat/TextFieldFlat.js
@@ -157,18 +157,20 @@ class TextFieldFlat extends Component {
           { marginBottom: helperText && helperVisible ? 20 : 0 },
           containerStyle,
         ]}>
-        <TextFieldLabel
-          label={label}
-          focused={focused}
-          error={error}
-          value={rest.value}
-          type={'flat'}
-          labelColor={labelColor}
-          style={labelStyle}
-          leadingIcon={leadingIcon}
-          dense={dense}
-          prefix={prefix}
-        />
+        {label ? (
+          <TextFieldLabel
+            label={label}
+            focused={focused}
+            error={error}
+            value={rest.value}
+            type={'flat'}
+            labelColor={labelColor}
+            style={labelStyle}
+            leadingIcon={leadingIcon}
+            dense={dense}
+            prefix={prefix}
+          />
+        ) : null}
         {leadingIcon ? this._renderLeadingIcon() : null}
         {prefix ? this._renderPrefix() : null}
         <TextInput

--- a/src/Components/TextField/TextFieldOutline/TextFieldOutline.js
+++ b/src/Components/TextField/TextFieldOutline/TextFieldOutline.js
@@ -153,18 +153,21 @@ class TextFieldOutlined extends Component {
           },
           containerStyle,
         ]}>
-        <TextFieldLabel
-          label={label}
-          focused={focused}
-          error={error}
-          value={rest.value}
-          type={'outlined'}
-          labelColor={labelColor}
-          style={labelStyle}
-          leadingIcon={leadingIcon}
-          dense={dense}
-          prefix={prefix}
-        />
+        {label ? (
+          <TextFieldLabel
+            label={label}
+            focused={focused}
+            error={error}
+            value={rest.value}
+            type={'outlined'}
+            labelColor={labelColor}
+            style={labelStyle}
+            leadingIcon={leadingIcon}
+            dense={dense}
+            prefix={prefix}
+          />
+        ) : null}
+
         {leadingIcon ? this._renderLeadingIcon() : null}
         {prefix ? this._renderPrefix() : null}
         <TextInput


### PR DESCRIPTION
Prevents situations like this from occurring:
![image](https://user-images.githubusercontent.com/2695365/61586364-00fa7900-ab27-11e9-9ba1-994db3e0995e.png)

After:
![image](https://user-images.githubusercontent.com/2695365/61586373-3010ea80-ab27-11e9-84f1-03dded2ae2b7.png)
