### PR TITLE
239-support-icon-sources

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -10,10 +10,15 @@ import results from '../.jest-test-results.json';
 import '@storybook/addon-console';
 
 // Generate required css
-const iconFont = require('react-native-vector-icons/Fonts/MaterialIcons.ttf');
+const materialIconFont = require('react-native-vector-icons/Fonts/MaterialIcons.ttf');
+const materialCommIconFont = require('react-native-vector-icons/Fonts/MaterialCommunityIcons.ttf');
 const iconFontStyles = `@font-face {
-  src: url(${iconFont}); 
+  src: url(${materialIconFont}); 
   font-family: MaterialIcons;
+}
+@font-face {
+  src: url(${materialCommIconFont}); 
+  font-family: MaterialCommunityIcons;
 }`;
 
 addParameters({

--- a/docs/src/content/components/icon/Demos/AnotherSourceDemo.js
+++ b/docs/src/content/components/icon/Demos/AnotherSourceDemo.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { View } from 'react-native';
+import { ComponentDemo, CodeInline } from '@components';
+import { Icon } from '../../../../../../src/index';
+import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
+
+export const code = `class DialogPage extends React.Component {
+  constructor(props) {
+    super(props)
+  }
+  render() {
+    return (
+      <View style={{ flexDirection: 'row', marginBottom: 20 }}>
+        <Icon
+          name="visual-studio-code"
+          size={24}
+          color={'#373177'}
+          iconComponent={MaterialCommunityIcons}
+        />
+        <Icon
+          name="android-head"
+          size={32}
+          color={'#69B342'}
+          iconComponent={MaterialCommunityIcons}
+        />
+        <Icon
+          name="apple-ios"
+          size={48}
+          color={'#000000'}
+          iconComponent={MaterialCommunityIcons}
+        />
+        <Icon
+          name="react"
+          size={64}
+          color={'#5FDAFB'}
+          iconComponent={MaterialCommunityIcons}
+        />
+      </View>
+    );
+  }
+}
+`;
+
+const SubtitleDemo = pageHref => (
+  <ComponentDemo
+    sectionName={'Source'}
+    sectionHref={`${pageHref}#source`}
+    sectionId={'source'}
+    description={
+      <div>
+        You can use other icon packs from{' '}
+        <CodeInline code="react-native-vector-icons" type="" /> by passing them
+        into <CodeInline code="MaterialCommunityIcons" type="proop" /> and
+        providing the icon name in the string.
+      </div>
+    }
+    code={code}
+    scope={{ View, Icon, MaterialCommunityIcons }}
+  />
+);
+export default SubtitleDemo;

--- a/docs/src/content/components/icon/Demos/index.js
+++ b/docs/src/content/components/icon/Demos/index.js
@@ -1,0 +1,20 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { ComponentDemoHeader } from '@components';
+
+import AnotherSourceDemo from './AnotherSourceDemo';
+
+export default class Demos extends Component {
+  static propTypes = {
+    pageHref: PropTypes.string,
+  };
+  render() {
+    const { pageHref } = this.props;
+    return (
+      <div>
+        <ComponentDemoHeader pageHref={pageHref} />
+        <AnotherSourceDemo pageHref={pageHref} />
+      </div>
+    );
+  }
+}

--- a/docs/src/content/components/icon/MainDemo.js
+++ b/docs/src/content/components/icon/MainDemo.js
@@ -23,13 +23,6 @@ export const code = `class IconPage extends React.Component {
         <Icon name="directions-walk" size={48} color={'#8BC34A'} />
 
         <Icon name="flash-on" size={64} color={'#FFEB3B'} />
-        
-        <Icon
-          name="react"
-          size={64}
-          color={'#5FDAFB'}
-          iconComponent={MaterialCommunityIcons}
-        />
       </View>
     );
   }
@@ -42,7 +35,9 @@ const MainDemo = pageHref => (
       <div>
         <CodeInline code="Icon" type="element" />s are provided by
         <CodeInline code="react-native-vector-icons" type="" />, you can learn
-        more about these icons in the style section on icons.
+        more about these icons in the style section on icons. The default icon
+        pack is MaterialIcons, but you can use aany that{' '}
+        <CodeInline code="react-native-vector-icons" type="" /> supports.
       </div>
     }
     code={code}

--- a/docs/src/content/components/icon/MainDemo.js
+++ b/docs/src/content/components/icon/MainDemo.js
@@ -23,6 +23,13 @@ export const code = `class IconPage extends React.Component {
         <Icon name="directions-walk" size={48} color={'#8BC34A'} />
 
         <Icon name="flash-on" size={64} color={'#FFEB3B'} />
+        
+        <Icon
+          name="react"
+          size={64}
+          color={'#5FDAFB'}
+          iconComponent={MaterialCommunityIcons}
+        />
       </View>
     );
   }

--- a/docs/src/content/components/icon/index.js
+++ b/docs/src/content/components/icon/index.js
@@ -3,8 +3,15 @@ import ComponentPageLayout from '../../../components/ComponentPage/ComponentPage
 import MainDemo from './MainDemo';
 import Usage from './Usage';
 import Props from './Props';
+import Demos from './Demos';
 
-const sections = [{ name: 'Component' }, { name: 'Usage' }, { name: 'Props' }];
+const sections = [
+  { name: 'Component' },
+  { name: 'Usage' },
+  { name: 'Props' },
+  { name: 'Demos' },
+  { name: 'source', sub: true },
+];
 
 export default class IconPage extends Component {
   render() {
@@ -20,6 +27,7 @@ export default class IconPage extends Component {
           <MainDemo pageHref={'/components/icon'} />
           <Usage pageHref={'/components/icon'} />
           <Props pageHref={'/components/icon'} />
+          <Demos pageHref={'/components/icon'} />
         </ComponentPageLayout>
       </div>
     );

--- a/docs/src/content/components/icon/propData.js
+++ b/docs/src/content/components/icon/propData.js
@@ -1,15 +1,15 @@
 import { createTableData } from '../../../utils/createPropData';
 const propData = [
   ['color', 'Icon Color', 'string', ''],
-  ['name', 'Name of icon that matches material names', 'string', ''],
-  ['size', 'Size of icon', 'number', ''],
-  ['style', 'Styles root element', 'object', ''],
   [
     'iconComponent',
     'One of the Icon components from react-native-vector-icons',
     'function',
     '',
   ],
+  ['name', 'Name of icon that matches material names', 'string', ''],
+  ['size', 'Size of icon', 'number', ''],
+  ['style', 'Styles root element', 'object', ''],
 ];
 
 export default createTableData(propData);

--- a/docs/src/content/components/icon/propData.js
+++ b/docs/src/content/components/icon/propData.js
@@ -4,6 +4,12 @@ const propData = [
   ['name', 'Name of icon that matches material names', 'string', ''],
   ['size', 'Size of icon', 'number', ''],
   ['style', 'Styles root element', 'object', ''],
+  [
+    'iconComponent',
+    'One of the Icon components from react-native-vector-icons',
+    'function',
+    '',
+  ],
 ];
 
 export default createTableData(propData);

--- a/docs/src/content/components/iconbutton/Demos/AnotherSourceDemo.js
+++ b/docs/src/content/components/iconbutton/Demos/AnotherSourceDemo.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { View } from 'react-native';
+import { ComponentDemo, CodeInline } from '@components';
+import { IconButton } from '../../../../../../src/index';
+import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
+
+export const code = `class DialogPage extends React.Component {
+  constructor(props) {
+    super(props)
+  }
+  render() {
+    return (
+      <View style={{ flexDirection: 'row', marginBottom: 20 }}>
+        <IconButton
+          name="visual-studio-code"
+          size={24}
+          color={'#373177'}
+          iconComponent={MaterialCommunityIcons}
+        />
+        <IconButton
+          name="android-head"
+          size={32}
+          color={'#69B342'}
+          iconComponent={MaterialCommunityIcons}
+        />
+        <IconButton
+          name="apple-ios"
+          size={48}
+          color={'#000000'}
+          iconComponent={MaterialCommunityIcons}
+        />
+        <IconButton
+          name="react"
+          size={64}
+          color={'#5FDAFB'}
+          iconComponent={MaterialCommunityIcons}
+        />
+      </View>
+    );
+  }
+}
+`;
+
+const SubtitleDemo = pageHref => (
+  <ComponentDemo
+    sectionName={'Source'}
+    sectionHref={`${pageHref}#source`}
+    sectionId={'source'}
+    description={
+      <div>
+        You can use other icon packs from{' '}
+        <CodeInline code="react-native-vector-icons" type="" /> by passing them
+        into <CodeInline code="MaterialCommunityIcons" type="proop" /> and
+        providing the icon name in the string.
+      </div>
+    }
+    code={code}
+    scope={{ View, IconButton, MaterialCommunityIcons }}
+  />
+);
+export default SubtitleDemo;

--- a/docs/src/content/components/iconbutton/Demos/index.js
+++ b/docs/src/content/components/iconbutton/Demos/index.js
@@ -1,0 +1,20 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { ComponentDemoHeader } from '@components';
+
+import AnotherSourceDemo from './AnotherSourceDemo';
+
+export default class Demos extends Component {
+  static propTypes = {
+    pageHref: PropTypes.string,
+  };
+  render() {
+    const { pageHref } = this.props;
+    return (
+      <div>
+        <ComponentDemoHeader pageHref={pageHref} />
+        <AnotherSourceDemo pageHref={pageHref} />
+      </div>
+    );
+  }
+}

--- a/docs/src/content/components/iconbutton/MainDemo.js
+++ b/docs/src/content/components/iconbutton/MainDemo.js
@@ -29,6 +29,13 @@ export const code = `class IconPage extends React.Component {
         <IconButton name="directions-walk" size={48} color={'#8BC34A'} />
 
         <IconButton name="flash-on" size={64} color={'#FFEB3B'} />
+
+        <IconButton
+          name="react"
+          size={64}
+          color={'#5FDAFB'}
+          iconComponent={MaterialCommunityIcons}
+        />
       </View>
     );
   }

--- a/docs/src/content/components/iconbutton/MainDemo.js
+++ b/docs/src/content/components/iconbutton/MainDemo.js
@@ -27,15 +27,7 @@ export const code = `class IconPage extends React.Component {
         <IconButton name="create" size={24} color={'#00BCD4'} />
         <IconButton name="dashboard" size={32} color={'#607D8B'} />
         <IconButton name="directions-walk" size={48} color={'#8BC34A'} />
-
         <IconButton name="flash-on" size={64} color={'#FFEB3B'} />
-
-        <IconButton
-          name="react"
-          size={64}
-          color={'#5FDAFB'}
-          iconComponent={MaterialCommunityIcons}
-        />
       </View>
     );
   }

--- a/docs/src/content/components/iconbutton/index.js
+++ b/docs/src/content/components/iconbutton/index.js
@@ -4,8 +4,15 @@ import ComponentPageLayout from '../../../components/ComponentPage/ComponentPage
 import MainDemo from './MainDemo';
 import Usage from './Usage';
 import Props from './Props';
+import Demos from './Demos';
 
-const sections = [{ name: 'Component' }, { name: 'Usage' }, { name: 'Props' }];
+const sections = [
+  { name: 'Component' },
+  { name: 'Usage' },
+  { name: 'Props' },
+  { name: 'Demos' },
+  { name: 'source', sub: true },
+];
 
 export default class IconPage extends Component {
   render() {
@@ -21,6 +28,7 @@ export default class IconPage extends Component {
           <MainDemo pageHref={'/components/iconbutton'} />
           <Usage pageHref={'/components/iconbutton'} />
           <Props pageHref={'/components/iconbutton'} />
+          <Demos pageHref={'/components/iconbutton'} />
         </ComponentPageLayout>
       </div>
     );

--- a/docs/src/content/components/iconbutton/propData.js
+++ b/docs/src/content/components/iconbutton/propData.js
@@ -1,17 +1,17 @@
 import { createTableData } from '../../../utils/createPropData';
 const propData = [
   ['color', 'Icon Color', 'string', ''],
-  ['name', 'Name of icon that matches material names', 'string', ''],
-  ['onPress', 'Callback on icon', 'func', ''],
-  ['rippleColor', 'Icon rippleColor overrides ripple color', 'string', 'color'],
-  ['size', 'Size of icon', 'number', ''],
-  ['style', 'Styles root element', 'object', ''],
   [
     'iconComponent',
     'One of the Icon components from react-native-vector-icons',
     'function',
     '',
   ],
+  ['name', 'Name of icon that matches material names', 'string', ''],
+  ['onPress', 'Callback on icon', 'func', ''],
+  ['rippleColor', 'Icon rippleColor overrides ripple color', 'string', 'color'],
+  ['size', 'Size of icon', 'number', ''],
+  ['style', 'Styles root element', 'object', ''],
 ];
 
 export default createTableData(propData);

--- a/docs/src/content/components/iconbutton/propData.js
+++ b/docs/src/content/components/iconbutton/propData.js
@@ -6,6 +6,12 @@ const propData = [
   ['rippleColor', 'Icon rippleColor overrides ripple color', 'string', 'color'],
   ['size', 'Size of icon', 'number', ''],
   ['style', 'Styles root element', 'object', ''],
+  [
+    'iconComponent',
+    'One of the Icon components from react-native-vector-icons',
+    'function',
+    '',
+  ],
 ];
 
 export default createTableData(propData);

--- a/docs/src/styles/global/global.css
+++ b/docs/src/styles/global/global.css
@@ -156,6 +156,10 @@ div[role='group'][tabindex] {
   src: url(../../../../node_modules/react-native-vector-icons/Fonts/MaterialIcons.ttf);
   font-family: MaterialIcons;
 }
+@font-face {
+  src: url(../../../../node_modules/react-native-vector-icons/Fonts/MaterialCommunityIcons.ttf);
+  font-family: MaterialCommunityIcons;
+}
 
 /**
  * Add back the container background-color, border-radius, padding, margin

--- a/src/Components/Icon/Icon.js
+++ b/src/Components/Icon/Icon.js
@@ -14,12 +14,23 @@ class Icon extends Component {
     size: PropTypes.number,
     name: PropTypes.string,
     testID: PropTypes.string,
+    iconComponent: PropTypes.func,
   };
   render() {
-    const { style, name, color, size, testID, ...rest } = this.props;
+    const {
+      style,
+      name,
+      color,
+      size,
+      testID,
+      iconComponent,
+      ...rest
+    } = this.props;
+
+    const IconComponent = iconComponent || MaterialIcons;
 
     return (
-      <MaterialIcons
+      <IconComponent
         pointerEvents="none"
         name={name}
         color={color}

--- a/src/Components/Icon/Icons.stories.js
+++ b/src/Components/Icon/Icons.stories.js
@@ -42,6 +42,12 @@ export default storiesOf('Components|Icons', module)
 
         <Icon name="flash-on" size={64} color={'#FFEB3B'} />
       </View>
+    </Container>
+  ))
+  .add('Another Source', () => (
+    <Container>
+      <Header title={'Icons from another source'} />
+
       <View style={{ flexDirection: 'row', marginBottom: 20 }}>
         <Icon
           name="visual-studio-code"

--- a/src/Components/Icon/Icons.stories.js
+++ b/src/Components/Icon/Icons.stories.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View } from 'react-native';
+import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 
 import { Icon, Badge } from '../../';
 import Header from '../../storybook/components/Header';
@@ -40,6 +41,32 @@ export default storiesOf('Components|Icons', module)
         <Icon name="directions-walk" size={48} color={'#8BC34A'} />
 
         <Icon name="flash-on" size={64} color={'#FFEB3B'} />
+      </View>
+      <View style={{ flexDirection: 'row', marginBottom: 20 }}>
+        <Icon
+          name="visual-studio-code"
+          size={24}
+          color={'#373177'}
+          iconComponent={MaterialCommunityIcons}
+        />
+        <Icon
+          name="android-head"
+          size={32}
+          color={'#69B342'}
+          iconComponent={MaterialCommunityIcons}
+        />
+        <Icon
+          name="apple-ios"
+          size={48}
+          color={'#000000'}
+          iconComponent={MaterialCommunityIcons}
+        />
+        <Icon
+          name="react"
+          size={64}
+          color={'#5FDAFB'}
+          iconComponent={MaterialCommunityIcons}
+        />
       </View>
     </Container>
   ));

--- a/src/Components/IconButton/IconButton.js
+++ b/src/Components/IconButton/IconButton.js
@@ -15,6 +15,7 @@ class IconButton extends Component {
     rippleColor: PropTypes.string,
     disabled: PropTypes.bool,
     testID: PropTypes.string,
+    iconComponent: PropTypes.func,
   };
   render() {
     const {
@@ -26,6 +27,7 @@ class IconButton extends Component {
       rippleColor,
       disabled,
       testID,
+      iconComponent,
       ...rest
     } = this.props;
     let rippleColorImplemented = color ? color : 'rgb(0, 0, 0)';
@@ -55,6 +57,7 @@ class IconButton extends Component {
           style={{
             backgroundColor: 'transparent',
           }}
+          iconComponent={iconComponent}
         />
       </Ripple>
     );

--- a/src/Components/IconButton/IconButton.stories.js
+++ b/src/Components/IconButton/IconButton.stories.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View } from 'react-native';
+import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 
 import { IconButton, Badge } from '../../';
 import Header from '../../storybook/components/Header';
@@ -36,6 +37,32 @@ export default storiesOf('Components|Icon Button', module)
         <IconButton name="directions-walk" size={48} color={'#8BC34A'} />
 
         <IconButton name="flash-on" size={64} color={'#FFEB3B'} />
+      </View>
+      <View style={{ flexDirection: 'row', marginBottom: 20 }}>
+        <IconButton
+          name="visual-studio-code"
+          size={24}
+          color={'#373177'}
+          iconComponent={MaterialCommunityIcons}
+        />
+        <IconButton
+          name="android-head"
+          size={32}
+          color={'#69B342'}
+          iconComponent={MaterialCommunityIcons}
+        />
+        <IconButton
+          name="apple-ios"
+          size={48}
+          color={'#000000'}
+          iconComponent={MaterialCommunityIcons}
+        />
+        <IconButton
+          name="react"
+          size={64}
+          color={'#5FDAFB'}
+          iconComponent={MaterialCommunityIcons}
+        />
       </View>
     </Container>
   ));

--- a/src/Components/IconButton/IconButton.stories.js
+++ b/src/Components/IconButton/IconButton.stories.js
@@ -38,6 +38,12 @@ export default storiesOf('Components|Icon Button', module)
 
         <IconButton name="flash-on" size={64} color={'#FFEB3B'} />
       </View>
+    </Container>
+  ))
+  .add('Another source', () => (
+    <Container>
+      <Header title={'Icons from another source'} />
+
       <View style={{ flexDirection: 'row', marginBottom: 20 }}>
         <IconButton
           name="visual-studio-code"


### PR DESCRIPTION
Added an iconComponet prop to Icon and IconButton to allow the user to pass in an icon component and falling back to MaterialIcons.

Fix for #239 