### PR TITLE
224 ListItem Truncation

### DIFF
--- a/src/Components/List/ListItem/ListItem.js
+++ b/src/Components/List/ListItem/ListItem.js
@@ -54,7 +54,7 @@ class ListItem extends Component {
             { color: disabled ? 'rgba(0,0,0,0.47)' : 'rgba(0,0,0,0.87)' },
             textStyle,
           ]}
-          ellipsizeMode="tail">
+          numberOfLines={1}>
           {text}
         </BodyText>
         {secondaryText ? (
@@ -63,7 +63,8 @@ class ListItem extends Component {
               styles.listItemSecondaryText,
               { color: 'rgba(0,0,0,0.57)' },
               secondaryTextStyle,
-            ]}>
+            ]}
+            numberOfLines={2}>
             {secondaryText}
           </Caption>
         ) : null}
@@ -209,7 +210,7 @@ class ListItem extends Component {
           {leadingActionItem ? this._renderLeadingActionItem() : null}
           {icon ? this._renderIcon() : null}
           {media ? media : null}
-          <View style={{ marginLeft: contentMargin }}>
+          <View style={{ marginLeft: contentMargin, flexShrink: 1 }}>
             {children ? children : this._renderText()}
           </View>
           {actionItem ? this._renderActionitem() : null}


### PR DESCRIPTION
Fixes for #224 

[Based on Material Design](https://material.io/design/components/lists.html#specs), the list item's title should be max of 1 line and the subtitle should be max of 2 lines.  This was implemented as well as adding flex-shrink to the container for the children/text.  Without this the flexed row allows the text to overflow.

Before:
<img width="389" alt="Screen Shot 2019-08-05 at 3 51 50 PM" src="https://user-images.githubusercontent.com/22638838/62493822-0fd86100-b7a0-11e9-80f0-43683699fb24.png">

After:
<img width="392" alt="Screen Shot 2019-08-05 at 4 39 05 PM" src="https://user-images.githubusercontent.com/22638838/62493865-1ff04080-b7a0-11e9-85f4-824b304c69ee.png">
