### PR TITLE
Dialog - Customize actionItems, title, and supportingText values

### DIFF
--- a/docs/src/content/components/dialog/propData.js
+++ b/docs/src/content/components/dialog/propData.js
@@ -16,8 +16,10 @@ const propData = [
     '',
   ],
   ['title', 'Adds a dialog title at the top', 'string', ''],
+  ['titleStyle', 'Additional styles for title', 'object', ''],
   ['style', 'Styles container dialog', 'object', ''],
   ['supportingText', 'Adds styled text below title', 'string', ''],
+  ['supportingTextStyle', 'Additional styles for supportingText', 'object', ''],
   ['visible', 'Wether to show dialog or not', 'bool', ''],
 ];
 

--- a/src/Components/Dialog/Dialog.js
+++ b/src/Components/Dialog/Dialog.js
@@ -19,7 +19,12 @@ class Dialog extends Component {
       PropTypes.oneOfType([PropTypes.node, PropTypes.object]),
     ),
     title: PropTypes.string,
+    titleStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     supportingText: PropTypes.string,
+    supportingTextStyle: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.array,
+    ]),
     contentStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     testID: PropTypes.string,
   };
@@ -40,7 +45,9 @@ class Dialog extends Component {
     const {
       style,
       title,
+      titleStyle,
       supportingText,
+      supportingTextStyle,
       children,
       actionItems,
       contentStyle,
@@ -48,9 +55,13 @@ class Dialog extends Component {
     return (
       <View style={[styles.container, style]}>
         <View style={[styles.contentContainer, contentStyle]}>
-          {title ? <BodyText style={styles.title}>{title}</BodyText> : null}
+          {title ? (
+            <BodyText style={[styles.title, titleStyle]}>{title}</BodyText>
+          ) : null}
           {supportingText ? (
-            <BodyText style={styles.supportingText}>{supportingText}</BodyText>
+            <BodyText style={[styles.supportingText, supportingTextStyle]}>
+              {supportingText}
+            </BodyText>
           ) : null}
           {children}
         </View>

--- a/src/Components/Dialog/Dialog.js
+++ b/src/Components/Dialog/Dialog.js
@@ -27,7 +27,8 @@ class Dialog extends Component {
     return (
       <View style={styles.actionItems}>
         {actionItems.map((item, index) => {
-          return <Button key={index} text={item.text} onPress={item.onPress} />;
+          if (React.isValidElement(item)) return item;
+          return <Button key={index} {...item} />;
         })}
       </View>
     );

--- a/src/Components/Dialog/Dialog.js
+++ b/src/Components/Dialog/Dialog.js
@@ -15,7 +15,9 @@ class Dialog extends Component {
     onRequestClose: PropTypes.func,
     onShow: PropTypes.func,
     onTouchOutside: PropTypes.func,
-    actionItems: PropTypes.array,
+    actionItems: PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.node, PropTypes.object]),
+    ),
     title: PropTypes.string,
     supportingText: PropTypes.string,
     contentStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),

--- a/src/Components/Dialog/Dialog.stories.js
+++ b/src/Components/Dialog/Dialog.stories.js
@@ -36,6 +36,7 @@ export default storiesOf('Components|Dialog', module)
                 },
                 {
                   text: 'Discard',
+                  type: 'contained',
                   onPress: () => store.set({ visible: false }),
                 },
               ]}


### PR DESCRIPTION
This PR:
- Adds `titleStyle` prop to allow customizing the Dialog title text
- Adds `supportingTextStyle` prop to allow customizing supporting text
- Adds the ability to put React elements in the `actionItems` prop
- If an object is in `actionItems`, it spreads those values on the `Button` component'
- Updates the docs for Dialog

![Screen Shot 2019-08-06 at 1 13 59 PM](https://user-images.githubusercontent.com/4458812/62561069-67cca180-b84c-11e9-88c1-2ad370798d7c.png)

![Screen Shot 2019-08-06 at 1 18 18 PM](https://user-images.githubusercontent.com/4458812/62561228-ad896a00-b84c-11e9-90c5-0c653e812f29.png)
