### PR TITLE
Fixed iOS mutiline inputs

### DIFF
--- a/docs/src/components/Drawer/DrawerHeader.js
+++ b/docs/src/components/Drawer/DrawerHeader.js
@@ -9,7 +9,7 @@ export default class DrawerContent extends React.PureComponent {
       <div style={styles.container}>
         <Logo width={77} height={64} style={{ width: 77 }} />
         <BodyText style={styles.title}>Material Bread</BodyText>
-        <BodyText style={styles.version}>v0.2.0</BodyText>
+        <BodyText style={styles.version}>v0.2.1</BodyText>
       </div>
     );
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "material-bread",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "jest -w 1 --forceExit",

--- a/src/Components/TextField/TextFieldFilled/TextFieldFilled.js
+++ b/src/Components/TextField/TextFieldFilled/TextFieldFilled.js
@@ -6,6 +6,7 @@ import TextFieldUnderline from '../TextFieldUnderline/TextFieldUnderline';
 import TextFieldLabel from '../TextFieldLabel/TextFieldLabel';
 import TextFieldHelperText from '../TextFieldHelperText/TextFieldHelperText';
 import styles from './TextFieldFilled.styles';
+import { nonOutlinedStops } from '../TextFieldLabel/TextFieldLabel.constants';
 
 class TextFieldFilled extends Component {
   constructor(props) {
@@ -44,6 +45,7 @@ class TextFieldFilled extends Component {
 
   state = {
     height: 56,
+    labelHeight: 0,
   };
 
   componentDidUpdate(prevProps) {
@@ -101,14 +103,23 @@ class TextFieldFilled extends Component {
   }
 
   _updateTextInputHeight = e => {
+    const { labelHeight } = this.state;
     if (!this.props.multiline) return;
 
     const nativeHeight = e.nativeEvent.contentSize.height;
 
+    const heightOffset =
+      Platform.OS === 'ios' ? labelHeight + nonOutlinedStops.active + 8 : 0;
     this.setState({
-      height: nativeHeight < 56 ? 56 : nativeHeight,
+      height: nativeHeight < 56 ? 56 : nativeHeight + heightOffset,
     });
   };
+
+  _measureLabel = ({
+    nativeEvent: {
+      layout: { height },
+    },
+  }) => this.setState({ labelHeight: height });
 
   render() {
     const {
@@ -147,7 +158,13 @@ class TextFieldFilled extends Component {
     let paddingLeft = leadingIcon ? 44 : 12;
     if (prefix) paddingLeft = 32;
 
-    const platformStyles = Platform.OS == 'web' ? { outlineWidth: 0 } : {};
+    const platformStyles = Platform.select({
+      web: { outlineWidth: 0 },
+      ios: {
+        marginTop: 8,
+      },
+      android: {},
+    });
     return (
       <View
         style={[
@@ -168,6 +185,7 @@ class TextFieldFilled extends Component {
             prefix={prefix}
             type={'filled'}
             focusedLabelColor={focusedLabelColor}
+            onLayout={this._measureLabel}
           />
         ) : null}
         {leadingIcon ? this._renderLeadingIcon() : null}
@@ -183,12 +201,13 @@ class TextFieldFilled extends Component {
               paddingBottom: rest.multiline ? 8 : 0,
               paddingTop: paddingTop,
               paddingLeft: paddingLeft,
-              paddingRight: trailingIcon || suffix ? 36 : 0,
+              paddingRight: trailingIcon || suffix ? 36 : 12,
             },
             style,
           ]}
           onContentSizeChange={e => this._updateTextInputHeight(e)}
           testID={testID}
+          scrollEnabled={false}
           {...rest}
           onFocus={handleFocus}
           onBlur={handleBlur}

--- a/src/Components/TextField/TextFieldFlat/TextFieldFlat.js
+++ b/src/Components/TextField/TextFieldFlat/TextFieldFlat.js
@@ -6,6 +6,7 @@ import TextFieldUnderline from '../TextFieldUnderline/TextFieldUnderline';
 import TextFieldLabel from '../TextFieldLabel/TextFieldLabel';
 import TextFieldHelperText from '../TextFieldHelperText/TextFieldHelperText';
 import styles from './TextFieldFlat.styles';
+import { nonOutlinedStops } from '../TextFieldLabel/TextFieldLabel.constants';
 
 class TextFieldFlat extends Component {
   constructor(props) {
@@ -44,6 +45,7 @@ class TextFieldFlat extends Component {
 
   static defaultProps = {
     helperVisible: true,
+    labelHeight: 0,
   };
 
   state = {
@@ -106,14 +108,23 @@ class TextFieldFlat extends Component {
   }
 
   _updateTextInputHeight = e => {
+    const { labelHeight } = this.state;
     if (!this.props.multiline) return;
 
     const nativeHeight = e.nativeEvent.contentSize.height;
 
+    const heightOffset =
+      Platform.OS === 'ios' ? labelHeight + nonOutlinedStops.active + 8 : 0;
     this.setState({
-      height: nativeHeight < 56 ? 56 : nativeHeight,
+      height: nativeHeight < 56 ? 56 : nativeHeight + heightOffset,
     });
   };
+
+  _measureLabel = ({
+    nativeEvent: {
+      layout: { height },
+    },
+  }) => this.setState({ labelHeight: height });
 
   render() {
     const {
@@ -151,7 +162,13 @@ class TextFieldFlat extends Component {
     let paddingLeft = leadingIcon ? 44 : 0;
     if (prefix) paddingLeft = 16;
 
-    const platformStyles = Platform.OS == 'web' ? { outlineWidth: 0 } : {};
+    const platformStyles = Platform.select({
+      web: { outlineWidth: 0 },
+      ios: {
+        marginTop: 8,
+      },
+      android: {},
+    });
 
     return (
       <View
@@ -173,6 +190,7 @@ class TextFieldFlat extends Component {
             dense={dense}
             prefix={prefix}
             focusedLabelColor={focusedLabelColor}
+            onLayout={this._measureLabel}
           />
         ) : null}
         {leadingIcon ? this._renderLeadingIcon() : null}
@@ -193,6 +211,7 @@ class TextFieldFlat extends Component {
             style,
           ]}
           testID={testID}
+          scrollEnabled={false}
           onContentSizeChange={e => this._updateTextInputHeight(e)}
           {...rest}
           onFocus={handleFocus}

--- a/src/Components/TextField/TextFieldLabel/TextFieldLabel.js
+++ b/src/Components/TextField/TextFieldLabel/TextFieldLabel.js
@@ -27,6 +27,7 @@ class TextFieldLabel extends Component {
     prefix: PropTypes.bool,
     theme: PropTypes.object,
     focusedLabelColor: PropTypes.string,
+    onLayout: PropTypes.func,
   };
 
   state = {
@@ -168,6 +169,7 @@ class TextFieldLabel extends Component {
       style,
       dense,
       focusedLabelColor,
+      onLayout,
     } = this.props;
     const { translateYAnimation, fontSizeAnimation } = this.state;
 
@@ -214,6 +216,7 @@ class TextFieldLabel extends Component {
             marginLeft: marginLeft,
           },
         ]}
+        onLayout={e => onLayout && onLayout(e)}
         pointerEvents="none">
         <Animated.Text
           style={[


### PR DESCRIPTION
Fixes #251 

By disabling scrolling for the iOS mutiline input and adding height accounting for the label height, the iOS mutliline input acts the same as the web and Android.