### PR TITLE
Bugfix/contained button flex

### DIFF
--- a/src/Utils/Hoverable/Hoverable.js
+++ b/src/Utils/Hoverable/Hoverable.js
@@ -1,5 +1,10 @@
 import React, { Component } from 'react';
-import { Platform, Dimensions, TouchableWithoutFeedback } from 'react-native';
+import {
+  Platform,
+  Dimensions,
+  TouchableWithoutFeedback,
+  View,
+} from 'react-native';
 import PropTypes from 'prop-types';
 
 class Hoverable extends Component {
@@ -75,14 +80,13 @@ class Hoverable extends Component {
       });
     } else {
       return (
-        <TouchableWithoutFeedback
-          style={{ flex: 1 }}
-          onPress={this._toggle}
-          testID={testID}>
-          {React.cloneElement(React.Children.only(child), {
-            onMouseEnter: this._handleMouseEnter,
-            onMouseLeave: this._handleMouseLeave,
-          })}
+        <TouchableWithoutFeedback onPress={this._toggle} testID={testID}>
+          <View style={{ flex: 1 }}>
+            {React.cloneElement(React.Children.only(child), {
+              onMouseEnter: this._handleMouseEnter,
+              onMouseLeave: this._handleMouseLeave,
+            })}
+          </View>
         </TouchableWithoutFeedback>
       );
     }


### PR DESCRIPTION
This PR adds `flex: 1` to the innerview of the `Hoverable` component when used with `react-native`. Before this PR it wasn't possible to flex two buttons next to each other:

![Screen Shot 2019-08-26 at 3 16 39 PM](https://user-images.githubusercontent.com/4458812/63719271-8f46d680-c81a-11e9-83b5-01c9856a6785.png)

After flexing that view, buttons now automatically size themselves when within a flex container:

![Screen Shot 2019-08-26 at 3 35 42 PM](https://user-images.githubusercontent.com/4458812/63719299-a1c11000-c81a-11e9-8610-a0f6235b82d7.png)
