### PR TITLE
feat:(TextFieldOutline): change border to 2px when active

### DIFF
--- a/src/Components/TextField/TextFieldOutline/TextFieldOutline.js
+++ b/src/Components/TextField/TextFieldOutline/TextFieldOutline.js
@@ -178,6 +178,7 @@ class TextFieldOutlined extends Component {
             styles.outlinedInput,
             platformStyles,
             {
+              borderWidth: focused ? 2 : 1,
               borderColor,
               minHeight: dense ? 40 : 56,
               height: height,

--- a/src/Components/TextField/TextFieldOutline/TextFieldOutline.styles.js
+++ b/src/Components/TextField/TextFieldOutline/TextFieldOutline.styles.js
@@ -9,7 +9,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: OUTLINED_LEFT_PADDING,
   },
   outlinedInput: {
-    borderWidth: 1,
     borderRadius: 4,
   },
 });

--- a/src/Components/TextField/TextFieldOutline/__snapshots__/TextFieldOutline.test.js.snap
+++ b/src/Components/TextField/TextFieldOutline/__snapshots__/TextFieldOutline.test.js.snap
@@ -25,11 +25,11 @@ exports[`TextFieldOutline Renders 1`] = `
         },
         Object {
           "borderRadius": 4,
-          "borderWidth": 1,
         },
         Object {},
         Object {
           "borderColor": "rgb(192, 192, 192)",
+          "borderWidth": 1,
           "height": 56,
           "minHeight": 56,
           "paddingBottom": 0,


### PR DESCRIPTION
Resolve #260 

Active
![Screenshot from 2019-08-27 22-46-32](https://user-images.githubusercontent.com/6487206/63819693-9fdf7580-c91c-11e9-9077-6957f1239c32.png)

Inactive
![Screenshot from 2019-08-27 22-46-37](https://user-images.githubusercontent.com/6487206/63819709-aec62800-c91c-11e9-8786-e250a9759f82.png)
