### PR TITLE
Add text props to ListItem

### DIFF
--- a/docs/src/content/components/list-item/propData.js
+++ b/docs/src/content/components/list-item/propData.js
@@ -23,10 +23,17 @@ const propData = [
     'string || element',
     '',
   ],
+  [
+    'secondaryTextProps',
+    'Addtional props for the secondary text element',
+    'object',
+    '',
+  ],
   ['secondaryTextStyle', 'Styles secondary text element', 'object', ''],
   ['selected', 'Whether the item is selected', 'bool', ''],
   ['style', 'Styles root element', 'object', ''],
   ['text', 'Main text for item', 'string', ''],
+  ['textProps', 'Addtional props for the main text element', 'object', ''],
   ['textStyle', 'Styles main text element', 'object', ''],
 ];
 

--- a/src/Components/List/ListItem/ListItem.js
+++ b/src/Components/List/ListItem/ListItem.js
@@ -18,7 +18,9 @@ class ListItem extends Component {
     disabled: PropTypes.bool,
     selected: PropTypes.bool,
     text: PropTypes.string,
+    textProps: PropTypes.object,
     secondaryText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    secondaryTextProps: PropTypes.object,
     media: PropTypes.node,
     icon: PropTypes.node,
     actionItem: PropTypes.node,
@@ -40,7 +42,9 @@ class ListItem extends Component {
   _renderText() {
     const {
       text,
+      textProps = {},
       secondaryText,
+      secondaryTextProps = {},
       disabled,
       textStyle,
       secondaryTextStyle,
@@ -54,7 +58,8 @@ class ListItem extends Component {
             { color: disabled ? 'rgba(0,0,0,0.47)' : 'rgba(0,0,0,0.87)' },
             textStyle,
           ]}
-          numberOfLines={1}>
+          numberOfLines={1}
+          {...textProps}>
           {text}
         </BodyText>
         {typeof secondaryText === 'string' ? (
@@ -64,7 +69,8 @@ class ListItem extends Component {
               { color: 'rgba(0,0,0,0.57)' },
               secondaryTextStyle,
             ]}
-            numberOfLines={2}>
+            numberOfLines={2}
+            {...secondaryTextProps}>
             {secondaryText}
           </Caption>
         ) : (


### PR DESCRIPTION
This PR adds in `textProps` and `secondaryTextProps` to the `ListItem` component. The change allows for more customization of how the text is rendered inside of a ListItem, such as changing `numberOfLines` from `1` to `2`.