### PR TITLE
fix: dialog

### DIFF
--- a/src/Components/Dialog/Dialog.js
+++ b/src/Components/Dialog/Dialog.js
@@ -64,8 +64,8 @@ class Dialog extends Component {
             </BodyText>
           ) : null}
           {children}
+          {actionItems ? this._renderActionItems() : null}
         </View>
-        {actionItems ? this._renderActionItems() : null}
       </View>
     );
   }

--- a/src/Components/Dialog/Dialog.styles.js
+++ b/src/Components/Dialog/Dialog.styles.js
@@ -15,6 +15,7 @@ const styles = StyleSheet.create({
     ...shadow(12),
   },
   contentContainer: {
+    flex: Platform.OS == 'web' ? 1 : 0,
     paddingLeft: 24,
     paddingRight: 24,
     paddingBottom: 8,


### PR DESCRIPTION
# WHY
The Dialog component wasn't displaying its actions on web because the scroll was invisible, whereas on mobile it shows the scroll but the actions are invisible.

## WEB
Before:
![web-before](https://user-images.githubusercontent.com/6487206/64491715-011f1700-d242-11e9-9a2b-eaafe2e086d8.png)

Fixed
![web-after](https://user-images.githubusercontent.com/6487206/64491727-0e3c0600-d242-11e9-871c-b8f6cecc781d.png)

## MOBILE
Before:
![mobile-before](https://user-images.githubusercontent.com/6487206/64491845-4132c980-d243-11e9-987f-1eeba73a066c.jpeg)

Fixed:
![mobile-after](https://user-images.githubusercontent.com/6487206/64491847-46901400-d243-11e9-8755-159ee6714cbb.jpeg)

