### PR TITLE
289 SheetBottom: Dynamic Height

### DIFF
--- a/src/Components/SheetBottom/SheetBottom.native.js
+++ b/src/Components/SheetBottom/SheetBottom.native.js
@@ -155,6 +155,7 @@ class SheetBottom extends Component {
 
   _close = () => {
     this.animateSheet(false);
+    this.setState({ initialHeight: 0 });
   };
 
   _onBackdropPress = () => {


### PR DESCRIPTION
The solution to this was to leverage what was already being done on inital layout.  When the sheet closes, initialHeight is set back to 0, thus forcing the component to measure itself on every render.  This will account for any height changes for any reason.

Fixes #289 