### PR TITLE
Spread input props on Searchfield

### DIFF
--- a/docs/src/content/components/searchfield/propData.js
+++ b/docs/src/content/components/searchfield/propData.js
@@ -1,12 +1,14 @@
 import { createTableData } from '../../../utils/createPropData';
 const propData = [
   ['color', 'Background color', 'string', 'white'],
+  ['iconProps', 'Override properties for the icons', 'object', ''],
   ['inputRef', 'Catch the reference of the TextInput component', 'func', ''],
   ['onChangeText', 'Callback when text is changed', 'func', ''],
   ['onCloseIcon', 'Callback when close icon is pressed', 'func', ''],
   ['onFocus', 'Callback when focused', 'func', ''],
   ['onBlur', 'Callback when blurred', 'func', ''],
   ['style', 'Styles root element', 'object', ''],
+  ['textStyle', 'Styles text input element', 'object', ''],
   ['value', 'Search input', 'string', ''],
 ];
 

--- a/src/Components/TextField/Searchfield/Searchfield.js
+++ b/src/Components/TextField/Searchfield/Searchfield.js
@@ -29,6 +29,7 @@ class Searchfield extends Component {
       color,
       placeholder,
       inputRef,
+      ...rest
     } = this.props;
 
     if (inputRef) {
@@ -55,6 +56,7 @@ class Searchfield extends Component {
           placeholderTextColor={'rgba(255,255,255,.57)'}
           onFocus={onFocus}
           onBlur={onBlur}
+          {...rest}
         />
 
         <IconButton

--- a/src/Components/TextField/Searchfield/Searchfield.js
+++ b/src/Components/TextField/Searchfield/Searchfield.js
@@ -7,28 +7,32 @@ import styles from './Searchfield.styles';
 
 class Searchfield extends Component {
   static propTypes = {
-    value: PropTypes.string,
-    style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+    color: PropTypes.string,
+    iconProps: PropTypes.object,
+    inputRef: PropTypes.func,
+    onBlur: PropTypes.func,
     onChangeText: PropTypes.func,
     onCloseIcon: PropTypes.func,
     onFocus: PropTypes.func,
-    onBlur: PropTypes.func,
-    color: PropTypes.string,
     placeholder: PropTypes.string,
-    inputRef: PropTypes.func,
+    style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+    textStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+    value: PropTypes.string,
   };
 
   render() {
     const {
-      style,
+      color,
+      iconProps,
+      inputRef,
+      onBlur,
       onChangeText,
       onCloseIcon,
-      value,
       onFocus,
-      onBlur,
-      color,
       placeholder,
-      inputRef,
+      style,
+      textStyle,
+      value,
       ...rest
     } = this.props;
 
@@ -43,13 +47,13 @@ class Searchfield extends Component {
           { backgroundColor: color ? color : 'rgba(255,255,255,.15)' },
           style,
         ]}>
-        <IconButton name={'search'} size={20} color={'white'} />
+        <IconButton name={'search'} size={20} color={'white'} {...iconProps} />
 
         <TextInput
           ref={ref => {
             this.textInput = ref;
           }}
-          style={styles.searchInput}
+          style={[styles.searchInput, textStyle]}
           placeholder={placeholder ? placeholder : 'Search'}
           value={value}
           onChangeText={onChangeText}
@@ -65,6 +69,7 @@ class Searchfield extends Component {
           style={{ opacity: !value || value.length < 1 ? 0 : 1 }}
           onPress={onCloseIcon}
           color={'white'}
+          {...iconProps}
         />
       </View>
     );


### PR DESCRIPTION
In order to properly use the search field the TextInput needs to be addressable with props.  In other places in the library, we've used the rest props for this.  I've included the rest props and added the to the TextInput.