### PR TITLE
Fix Appbar's elevation

### DIFF
--- a/src/Components/Appbar/Appbar.js
+++ b/src/Components/Appbar/Appbar.js
@@ -194,7 +194,10 @@ class Appbar extends Component {
     } = this.props;
 
     let backgroundColor = color ? color : theme.primary.main;
-    const implementedShadow = elevation ? shadow(shadow) : shadow(6);
+    const implementedShadow =
+      elevation != undefined || elevation != null
+        ? shadow(elevation)
+        : shadow(6);
 
     return (
       <Paper


### PR DESCRIPTION
With the following code:

`
<Appbar title='Test' elevation={1} />
`

iOS before:
![image](https://user-images.githubusercontent.com/1257907/66179329-b357cc00-e692-11e9-8be0-ae4c5d5b3bef.png)

iOS after:
![image](https://user-images.githubusercontent.com/1257907/66179394-00d43900-e693-11e9-8e7e-912dd4343e2f.png)


Android before:
![image](https://user-images.githubusercontent.com/1257907/66179348-c7033280-e692-11e9-8a64-487690e6dbec.png)


Android after:
![image](https://user-images.githubusercontent.com/1257907/66179405-0c276480-e693-11e9-9fb2-a1de1652f52e.png)
