### PR TITLE
Adjustments for line height in the text label

### DIFF
--- a/src/Components/TextField/TextFieldFilled/TextFieldFilled.js
+++ b/src/Components/TextField/TextFieldFilled/TextFieldFilled.js
@@ -171,7 +171,7 @@ class TextFieldFilled extends Component {
             label={label}
             focused={focused}
             error={error}
-            value={rest.value && rest.value.length > 0}
+            value={rest.value}
             labelColor={labelColor}
             style={labelStyle}
             leadingIcon={!!leadingIcon}

--- a/src/Components/TextField/TextFieldLabel/TextFieldLabel.js
+++ b/src/Components/TextField/TextFieldLabel/TextFieldLabel.js
@@ -201,10 +201,19 @@ class TextFieldLabel extends Component {
       theme.subtitleOne.fontSize ||
       16;
 
+    const baseLineHeight =
+      (StyleSheet.flatten(style) || {}).lineHeight ||
+      theme.subtitleOne.lineHeight ||
+      24;
+
     const fontStyle = {
       fontSize: fontSizeAnimation.interpolate({
         inputRange: [0, 1],
         outputRange: [baseFontSize, baseFontSize * (dense ? 0.65 : 0.75)],
+      }),
+      lineHeight: fontSizeAnimation.interpolate({
+        inputRange: [0, 1],
+        outputRange: [baseLineHeight, baseLineHeight * (dense ? 0.5 : 0.6)],
       }),
     };
 


### PR DESCRIPTION
The line height was not being scaled with the font size.  This lead to the height of the actual label not changing when it was animated to the active state.  Also removed the annoying value result that raises a proptypes warning when value is empty.