### PR TITLE
Added prop to use input casing for buttons

### DIFF
--- a/docs/src/content/components/button/propData.js
+++ b/docs/src/content/components/button/propData.js
@@ -60,6 +60,13 @@ const propData = [
     'string: flat, text, outlined, contained',
     'text',
   ],
+
+  [
+    'useInputCasing',
+    'Use text casing as input and do not auto-capitalize',
+    'boolean',
+    'false',
+  ],
 ];
 
 export default createTableData(propData);

--- a/src/Components/Button/ButtonBase/ButtonBase.js
+++ b/src/Components/Button/ButtonBase/ButtonBase.js
@@ -32,6 +32,7 @@ class ButtonBase extends Component {
 
     text: PropTypes.string,
     textStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+    useInputCasing: PropTypes.bool,
 
     typeTextColor: PropTypes.string,
     typeButtonStyles: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
@@ -44,6 +45,7 @@ class ButtonBase extends Component {
   static defaultProps = {
     iconPosition: 'left',
     dense: false,
+    useInputCasing: false,
   };
 
   _renderText() {
@@ -54,6 +56,7 @@ class ButtonBase extends Component {
       theme,
       hideLabel,
       dense,
+      useInputCasing,
     } = this.props;
 
     if (hideLabel) return null;
@@ -69,7 +72,7 @@ class ButtonBase extends Component {
           },
           textStyle,
         ]}>
-        {text.toUpperCase()}
+        {useInputCasing ? text : text.toUpperCase()}
       </Text>
     );
   }


### PR DESCRIPTION
By default in Material, buttons should be capitalized, but this gives the user the option to use input casing in case their designs have text in a button that is not capitalized.  Children could also be used here, but this solution uses MB's own rendering to accomplish it which seems easier to use and more consistent than children.