### PR TITLE
focusedBorderColor property was added to support customized border color

### DIFF
--- a/src/Components/TextField/TextFieldOutline/TextFieldOutline.js
+++ b/src/Components/TextField/TextFieldOutline/TextFieldOutline.js
@@ -33,6 +33,7 @@ class TextFieldOutlined extends Component {
     prefix: PropTypes.node,
     testID: PropTypes.string,
     focusedLabelColor: PropTypes.string,
+    focusedBorderColor: PropTypes.string,
   };
 
   static defaultProps = {
@@ -128,10 +129,14 @@ class TextFieldOutlined extends Component {
       prefix,
       testID,
       focusedLabelColor,
+      focusedBorderColor,
       ...rest
     } = this.props;
 
-    let borderColor = focused ? 'rgba(33, 150, 243, 1)' : 'rgb(192, 192, 192)';
+    let borderColor = focused
+      ? focusedBorderColor || 'rgba(33, 150, 243, 1)'
+      : 'rgb(192, 192, 192)';
+
     if (error) borderColor = 'red';
 
     let height =


### PR DESCRIPTION
## Description

This PR enable user to set focus color in outlined textfield.

## Screenshots
![Screen Shot 2019-11-20 at 12 57 38 PM](https://user-images.githubusercontent.com/7472461/69264458-602fcf00-0b95-11ea-8966-1f54120f670c.png)
