### PR TITLE
SpedDial with only one fab button is now able to execute onPress function.

### DIFF
--- a/src/Components/Fab/FabSpeedDial/FabSpeedDial.js
+++ b/src/Components/Fab/FabSpeedDial/FabSpeedDial.js
@@ -46,7 +46,8 @@ class FabSpeedDial extends Component {
   }
 
   animateActions() {
-    const { open, onPress } = this.state;
+    const { onPress } = this.props;
+    const { open } = this.state;
 
     this.setState({
       open: !open,


### PR DESCRIPTION
## Description
This PR enable user to use onPress function on fabdial element. in order to use like a single fab button. This is useful to avoid replace fabdial with fab button in cases where you only need a single element.

## Screenshots

![ezgif com-video-to-gif-6](https://user-images.githubusercontent.com/7472461/69265790-e1886100-0b97-11ea-8517-643a7e788225.gif)
