### PR TITLE
Now ripple is able to run when is press out.

### DIFF
--- a/src/Components/Ripple/Ripple.js
+++ b/src/Components/Ripple/Ripple.js
@@ -98,6 +98,10 @@ export default class Ripple extends PureComponent {
 
     if ('function' === typeof onPress) {
       requestAnimationFrame(() => onPress(event));
+      let { locationX, locationY } = event.nativeEvent;
+      if (locationX != undefined && locationY != undefined) {
+        this.startRipple(event);
+      }
     }
   }
 
@@ -122,8 +126,6 @@ export default class Ripple extends PureComponent {
       if (onPressIn) {
         onPressIn(event);
       }
-
-      this.startRipple(event);
     }
   }
 


### PR DESCRIPTION
## Description
This PR change the way ripple effect works. Now ripple effect will be triggered with press out. This to fix the issue that show ripple effect when you are dragging a ripple element.

## Screenshot

![ezgif com-video-to-gif-7](https://user-images.githubusercontent.com/7472461/69266326-f5809280-0b98-11ea-95d8-4b37715b2bf2.gif)
