### PR TITLE
Make filled text field send value prop type consistent with other TextField components

### DIFF
--- a/src/Components/TextField/TextFieldFilled/TextFieldFilled.js
+++ b/src/Components/TextField/TextFieldFilled/TextFieldFilled.js
@@ -171,7 +171,7 @@ class TextFieldFilled extends Component {
             label={label}
             focused={focused}
             error={error}
-            value={rest.value && rest.value.length > 0}
+            value={rest.value}
             labelColor={labelColor}
             style={labelStyle}
             leadingIcon={!!leadingIcon}


### PR DESCRIPTION
I was getting a yellow box when using the TextFieldFilled component (see #364). it looks like this is how value is being passed by the other TextField components and a quick check shows `''` evals to falsy the way it's being used in TextFieldLabel, so no need for the length check, I think.