### PR TITLE
Add `containerStyle` prop to `Tab`, fix various yellowboxes

### DIFF
--- a/src/Components/Tabs/Tab/Tab.js
+++ b/src/Components/Tabs/Tab/Tab.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import { View, Text } from 'react-native';
+import { View, ViewPropTypes, Text } from 'react-native';
 import Ripple from '../../Ripple/Ripple.js';
 import Icon from '../../Icon/Icon.js';
 import withTheme from '../../../Theme/withTheme';
@@ -12,6 +12,7 @@ class Tab extends Component {
     label: PropTypes.string,
     active: PropTypes.bool,
     activeTextColor: PropTypes.string,
+    containerStyle: ViewPropTypes.style,
     inActiveTextColor: PropTypes.string,
     textStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     iconStyles: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
@@ -25,6 +26,7 @@ class Tab extends Component {
   static defaultProps = {
     inActiveTextColor: 'rgba(255, 255, 255, 0.7)',
     activeTextColor: '#fff',
+    containerStyle: {},
   };
 
   _renderIcon(color) {
@@ -54,6 +56,7 @@ class Tab extends Component {
       label,
       active,
       activeTextColor,
+      containerStyle,
       inActiveTextColor,
       icon,
     } = this.props;
@@ -61,7 +64,7 @@ class Tab extends Component {
     const color = active ? activeTextColor : inActiveTextColor;
 
     return (
-      <View style={styles.container}>
+      <View style={[styles.container, containerStyle]}>
         {icon ? this._renderIcon(color) : null}
         {label ? this._renderText(color) : null}
       </View>

--- a/src/Components/Tabs/Tabs.js
+++ b/src/Components/Tabs/Tabs.js
@@ -48,9 +48,12 @@ class Tabs extends Component {
   }
 
   shouldComponentUpdate(nextProps) {
+    const { actionItems } = this.props;
+
     return (
-      nextProps.selectedIndex < nextProps.actionItems.length &&
-      nextProps.selectedIndex >= 0
+      actionItems.length !== nextProps.actionItems.length ||
+      (nextProps.selectedIndex < nextProps.actionItems.length &&
+        nextProps.selectedIndex >= 0)
     );
   }
 

--- a/src/Components/Tabs/Tabs.js
+++ b/src/Components/Tabs/Tabs.js
@@ -10,7 +10,9 @@ export const TabsContext = React.createContext();
 
 class Tabs extends Component {
   static propTypes = {
-    actionItems: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    actionItems: PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.object, PropTypes.element]),
+    ),
     selectedIndex: PropTypes.number,
     backgroundColor: PropTypes.string,
     underlineColor: PropTypes.string,

--- a/src/Components/Tabs/Underline/Underline.js
+++ b/src/Components/Tabs/Underline/Underline.js
@@ -8,7 +8,10 @@ import styles from './Undrline.styles';
 class Underline extends Component {
   static propTypes = {
     color: PropTypes.string,
-    value: PropTypes.string,
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.instanceOf(Animated.Value),
+    ]),
     tabWidth: PropTypes.number,
   };
 


### PR DESCRIPTION
This PR adds in a `containerStyle` prop to the `Tab` component to be able to override the default styles applied. I've also fixed a handful of yellowboxes I discovered while using `Tabs` and `Tab`