### PR TITLE
Fix crash when using checkedIcon and add support disabled color

### DIFF
--- a/src/Components/Checkbox/Checkbox.js
+++ b/src/Components/Checkbox/Checkbox.js
@@ -15,6 +15,7 @@ class Checkbox extends Component {
     rippleColor: PropTypes.string,
     checkboxColor: PropTypes.string,
     unCheckedColor: PropTypes.string,
+    disabledColor: PropTypes.string,
     style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     checkboxStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
     theme: PropTypes.object,
@@ -58,14 +59,14 @@ class Checkbox extends Component {
   }
 
   _getCheckBoxColor() {
-    const { disabled, checkboxColor, theme, error } = this.props;
+    const { disabled, checkboxColor, disabledColor, theme, error } = this.props;
     let checkboxColorApplied = checkboxColor
       ? checkboxColor
       : theme.primary.main;
 
     if (error) checkboxColorApplied = theme.error.main;
 
-    if (disabled) checkboxColorApplied = 'rgba(0,0,0,.5)';
+    if (disabled) checkboxColorApplied = disabledColor || 'rgba(0,0,0,.5)';
 
     return checkboxColorApplied;
   }
@@ -133,7 +134,7 @@ class Checkbox extends Component {
       checked
     ) {
       return React.cloneElement(checkedIcon, {
-        size: icon.props.size ? icon.props.size : size,
+        size: checkedIcon.props.size ? checkedIcon.props.size : size,
         color: checkboxColor,
       });
     }


### PR DESCRIPTION
This PR fix an issue on Checkbox component. When using "checkedIcon", the app will crash if I didn't send "icon" props. Because it get related value from "icon". Also this PR added a new props "disabledColor". If user need a custom color for when disable, current component didn't support it.